### PR TITLE
added copy all (as csv) function to results display

### DIFF
--- a/lib/quick-query-mysql-connection.coffee
+++ b/lib/quick-query-mysql-connection.coffee
@@ -121,10 +121,6 @@ class QuickQueryMysqlConnection
       else if !fields
         message = { type: 'success', content:  rows.affectedRows+" row(s) affected" }
 
-      console.log(err)
-      console.log(rows)
-      console.log(fields)
-
       callback(message,rows,fields)
 
   setDefaultDatabase: (database)->

--- a/lib/quick-query-result-view.coffee
+++ b/lib/quick-query-result-view.coffee
@@ -99,7 +99,7 @@ class QuickQueryResultView extends View
       if (err)
         console.log(err)
       else
-        atom.clipboard.write(csv)   
+        atom.clipboard.write(csv)
 
   saveCSV: ->
     if @rows? && @fields? && @is(':visible')

--- a/lib/quick-query-result-view.coffee
+++ b/lib/quick-query-result-view.coffee
@@ -10,6 +10,7 @@ class QuickQueryResultView extends View
   constructor:  ()->
     atom.commands.add '.quick-query-result',
      'quick-query:copy': => @copy()
+     'quick-query:copyall': => @copyall()
      'quick-query:save-csv': => @saveCSV()
      'quick-query:insert': => @insertRecord() if @is(':visible')
      'quick-query:null': => @setNull()
@@ -86,6 +87,19 @@ class QuickQueryResultView extends View
     $td = @find('td.selected')
     if $td.length == 1 && @is(':visible')
       atom.clipboard.write($td.text())
+
+  copyall: ->
+    fields = JSON.parse(JSON.stringify(@fields))
+    fields = @fields.map (field) -> field.name
+    rows = @rows.map (row) ->
+      simpleRow = JSON.parse(JSON.stringify(row))
+      simpleRow[field] ?= '' for field in fields
+      simpleRow
+    json2csv  data: rows , fields: fields , (err, csv)->
+      if (err)
+        console.log(err)
+      else
+        atom.clipboard.write(csv)   
 
   saveCSV: ->
     if @rows? && @fields? && @is(':visible')

--- a/lib/quick-query.coffee
+++ b/lib/quick-query.coffee
@@ -159,16 +159,33 @@ module.exports = QuickQuery =
           @setModalPanel(message)
           if message.type == 'success'
             @afterExecute(@queryEditor)
-        else
-          if atom.config.get('quick-query.resultsInTab')
-            queryResult = @showResultInTab()
-          else
-            queryResult = @showResultView(@queryEditor)
-          queryResult.showRows(rows, fields, @connection)
-          queryResult.fixSizes()
-          @modalPanel.hide() if @modalPanel
+        # else
+        if Array.isArray(rows)
+          @generateResults(rows, fields, @connection)
+          # if atom.config.get('quick-query.resultsInTab')
+          #   queryResult = @showResultInTab()
+          # else
+          #   queryResult = @showResultView(@queryEditor)
+          # queryResult.showRows(rows, fields, @connection)
+          # queryResult.fixSizes()
+          # @modalPanel.hide() if @modalPanel
     else
       @setModalPanel content: "No connection selected"
+
+  generateResults: (rows, fields, connection) ->
+    if Array.isArray(rows[0])
+      for rowset, i in rows
+        @generateOnePageOfResults(rows[i], fields[i], connection)
+    else
+      @generateOnePageOfResults(rows, fields, connection)
+
+  generateOnePageOfResults: (rows, fields, connection) ->
+    if atom.config.get('quick-query.resultsInTab')
+      queryResult = @showResultInTab()
+    else
+      queryResult = @showResultView(@queryEditor)
+    queryResult.showRows(rows, fields, @connection)
+    queryResult.fixSizes()
 
   toggleBrowser: ->
     if @browser.is(':visible')
@@ -211,13 +228,13 @@ module.exports = QuickQuery =
 
   showResultInTab: ->
     pane = atom.workspace.getActivePane()
-    filter = pane.getItems().filter (item) ->
-      item instanceof QuickQueryResultView
-    if filter.length == 0
-      queryResult = new QuickQueryResultView()
-      pane.addItem queryResult
-    else
-      queryResult = filter[0]
+    # filter = pane.getItems().filter (item) ->
+    #   item instanceof QuickQueryResultView
+    # if filter.length == 0
+    queryResult = new QuickQueryResultView()
+    pane.addItem queryResult
+    # else
+    #   queryResult = filter[0]
     pane.activateItem queryResult
     queryResult
 

--- a/lib/quick-query.coffee
+++ b/lib/quick-query.coffee
@@ -159,16 +159,8 @@ module.exports = QuickQuery =
           @setModalPanel(message)
           if message.type == 'success'
             @afterExecute(@queryEditor)
-        # else
         if Array.isArray(rows)
           @generateResults(rows, fields, @connection)
-          # if atom.config.get('quick-query.resultsInTab')
-          #   queryResult = @showResultInTab()
-          # else
-          #   queryResult = @showResultView(@queryEditor)
-          # queryResult.showRows(rows, fields, @connection)
-          # queryResult.fixSizes()
-          # @modalPanel.hide() if @modalPanel
     else
       @setModalPanel content: "No connection selected"
 
@@ -228,13 +220,8 @@ module.exports = QuickQuery =
 
   showResultInTab: ->
     pane = atom.workspace.getActivePane()
-    # filter = pane.getItems().filter (item) ->
-    #   item instanceof QuickQueryResultView
-    # if filter.length == 0
     queryResult = new QuickQueryResultView()
     pane.addItem queryResult
-    # else
-    #   queryResult = filter[0]
     pane.activateItem queryResult
     queryResult
 

--- a/menus/quick-query.cson
+++ b/menus/quick-query.cson
@@ -36,6 +36,7 @@
     {'label': 'New record', 'command': 'quick-query:insert'}
     {'label': 'Get changes\' SQL', 'command': 'quick-query:apply'}
     {'type': 'separator'}
+    {'label': 'Copy All as CSV', 'command': 'quick-query:copyall'}
     {'label': 'Save as CSV', 'command': 'quick-query:save-csv'}
   ]
   '.quick-query-browser .qq-connection-item':[


### PR DESCRIPTION
Wanted the ability to copy all results as csv so I could directly paste into other applications without first saving to a file. 

Did not move csv creation to another method. Just copied code from 'save as'. Left it this way to allow for customization of copy all without effecting save all functionality.
